### PR TITLE
Fixing issue 1

### DIFF
--- a/Plugin List/TAB/config.yml
+++ b/Plugin List/TAB/config.yml
@@ -48,8 +48,8 @@ Groups:
       
   #default settings for all groups, all groups will take properties from this section unless player's primary group overrides a specific setting
   _OTHER_:
-    tabprefix: "%vault-prefix% "
-    tagprefix: "%vault-prefix% "
+    tabprefix: "%vault-prefix%"
+    tagprefix: "%vault-prefix%"
     tabsuffix: "%afk%"
     tagsuffix: "%afk%"
     customtabname: "%essentialsnick%"

--- a/Plugin List/VaultChatFormatter/config.yml
+++ b/Plugin List/VaultChatFormatter/config.yml
@@ -14,4 +14,4 @@
 # {message} ==> the message being sent by the player
 #
 # Standard Minecraft color codes can be used in the format.
-format: "{prefix} {name}{suffix} : &7{message}"
+format: "{prefix}{name}{suffix} : &7{message}"


### PR DESCRIPTION
Solved by removing extra indentures for the default group and giving extra spaces at the end of staff prefixes in order to keep the space needed