### PR TITLE
v2.12

### DIFF
--- a/Plugin List/ClearLag/config.yml
+++ b/Plugin List/ClearLag/config.yml
@@ -40,7 +40,7 @@ global-broadcasts:
 # -- 'follow-stack' Should Clearlag keep printing the stacktrace every time it changes (Can be very spammy)?
 # Help-> https://dev.bukkit.org/projects/clearlagg/pages/finding-the-cause-of-lag-spikes
 lag-spike-helper:
-  enabled: false
+  enabled: true
   min-elapsed-time: 500
   check-interval: 100
   follow-stack: true
@@ -101,10 +101,10 @@ player-speed-limiter:
 item-spawn-age-setter:
   enabled: false
   items:
-    stone: 240
+    stone: 20
     grass: 240
-    cobblestone: 240
-    log: 240
+    cobblestone: 20
+    log: 60
     stone_axe: 240
     stone_pickaxe: 240
     stone_sword: 240
@@ -141,7 +141,7 @@ mob-breeding-limiter:
 # -- 'days-old' means how many days old can the log be to be deleted
 log-purger:
   enabled: false
-  days-old: 3
+  days-old: 2
 
 #What type of entities SHOULD NOT be removed while doing /lagg area?
 area-filter:

--- a/Plugin List/GriefPreventionData/config.yml
+++ b/Plugin List/GriefPreventionData/config.yml
@@ -58,7 +58,7 @@ GriefPrevention:
     FireDamagesInClaims: false
     LecternReadingRequiresAccessTrust: true
   Spam:
-    Enabled: true
+    Enabled: false
     LoginCooldownSeconds: 60
     LoginLogoutNotificationsPerMinute: 5
     ChatSlashCommands: /me;/global;/local


### PR DESCRIPTION
In preperation for the 2.12 release, we have:
1. a7de54e Pronounced changes to anti-lag though none of them were related with the issue #18 
2. 73e91d9 Denied spam plugin permissions to spawn spam on behalf of suggestion `#51`
3. Bugfix with running `/coords` would give error