### PR TITLE
Player respawn location

### DIFF
--- a/Plugin List/Essentials/config.yml
+++ b/Plugin List/Essentials/config.yml
@@ -1074,10 +1074,10 @@ respawn-listener-priority: high
 spawn-join-listener-priority: high
 
 # When users die, should they respawn at their first home or bed, instead of the spawnpoint?
-respawn-at-home: false
+respawn-at-home: true
 
 # When users die, should EssentialsSpawn respect users' respawn anchors?
-respawn-at-anchor: false
+respawn-at-anchor: true
 
 # Teleport all joining players to the spawnpoint
 spawn-on-join: false


### PR DESCRIPTION
Set player respawn location at their anchor or bed, in order to fix issue #25. Based on discord suggestion `#63` by FoxyTriples.