### PR TITLE
v2.12d

### DIFF
--- a/Plugin List/ClearLag/config.yml
+++ b/Plugin List/ClearLag/config.yml
@@ -355,7 +355,7 @@ item-merger:
 # -- 'remove-entities' What entities SHOULD be removed during removal
 auto-removal:
   enabled: true
-  broadcast-message: '&6[ClearLag] &aRemoved +RemoveAmount Entiti(e/s)!'
+  broadcast-message: '&6[ClearLag] &aRemoved +RemoveAmount Entities!'
   broadcast-removal: true
   autoremoval-interval: 200
   world-filter:
@@ -386,8 +386,6 @@ auto-removal:
   # - Minecart !isMounted <- This entity will be REMOVED if it's NOT mounted
   # - Wolf !hasName <- This entity will be REMOVED if it doesn't have a name
   warnings:
-        - 'time:100 msg:&4[ClearLag] &cWarning Ground items will be removed in &7+remaining &cseconds!'
-        - 'time:140 msg:&4[ClearLag] &cWarning Ground items will be removed in &7+remaining &cseconds!'
         - 'time:195 msg:&4[ClearLag] &cGround items getting removed in &7+remaining &cseconds'
 
 #What should be removed during /lagg clear, nearly the same thing as auto-removal


### PR DESCRIPTION
- Is this a general improvement/enhancement: `[Yes]`
- Is this an attempt at fixing an issue `[No]` `[]`
- What is the server version you are attempting to release this in `[v2.12d]`
- Is this based on a poll/suggestion? If so, which `[Discord Poll: 'Remove Clearlag chat warnings (apart from 30 seconds) since they flood the chat']`
##### Changelog:
Purge warnings before:
![image](https://user-images.githubusercontent.com/53821637/113331954-db27fe80-9320-11eb-9779-1639528c2a10.png)
and after:
![image](https://user-images.githubusercontent.com/53821637/113332017-f0049200-9320-11eb-85f7-c8348a7597f1.png)
