### PR TITLE
Added /grave to give user a grave key

### DIFF
--- a/Home Directory Files/commands.yml
+++ b/Home Directory Files/commands.yml
@@ -38,4 +38,5 @@ aliases:
   - customtext git $1
   coords:
   - trigger ch_toggle $1
-
+  grave:
+  - function graves:give_grave_key $1


### PR DESCRIPTION
The grave key is used to open player's graves when grave looting is disabled

- Is this a general improvement/enhancement: **[Yes]**
- Is this an attempt at fixing an issue **[None of the former]** **[]`
- What is the server version you are attempting to release this in **[v2.12e]**
##### Changelog:
1. Added /grave to give the user a grave key. This is used to open graves when grave looting is disabled

